### PR TITLE
Disable mavlink log for now

### DIFF
--- a/main.conf
+++ b/main.conf
@@ -2,9 +2,6 @@
     TcpServerPort=5760
     ReportStats=false
     MavlinkDialect=auto
-    Log=/home/sad/px4-logs/
-    LogMode=while-armed
-    MaxLogFiles=50
 
 [UdpEndpoint protocol-splitter]
     Mode = Server


### PR DESCRIPTION
This eats up the bandwidth from UART. This might be re-enabled after we switch
to ethernet based communication, if needed.

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>