### PR TITLE
Enable multiarch builds

### DIFF
--- a/.github/workflows/tii-mavlink-router.yaml
+++ b/.github/workflows/tii-mavlink-router.yaml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   tii-mavlink-router:
     runs-on: ubuntu-latest
@@ -17,7 +21,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: riscv64
+          platforms: amd64,riscv64,arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -44,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/amd64,linux/riscv64
+          platforms: linux/amd64,linux/riscv64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM ${TARGETARCH}/ubuntu:20.04 as builder
+# Due to different naming convention, use this workaround
+FROM ubuntu:22.04 as builder-amd64
+FROM ubuntu:22.04 as builder-arm64
+FROM riscv64/ubuntu:22.04 as builder-riscv64
+
+FROM builder-${TARGETARCH} as builder
 
 # Setup timezone
 RUN echo 'Etc/UTC' > /etc/timezone \
@@ -21,7 +26,7 @@ RUN ./autogen.sh \
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ${TARGETARCH}/ubuntu:20.04
+FROM builder-${TARGETARCH} as runtime
 
 # Setup timezone
 RUN echo 'Etc/UTC' > /etc/timezone \


### PR DESCRIPTION
The version in main only can build for amd64 and riscv64. This enabled arm64 as well.

One of the workflows, Build and Tests fails. We only need the tii-mavlink-router, so it is not a blocker for us. The upstream updated version `upstream_master_11_05_2023-logging-stop-fix` doesn't have the problem.