### PR TITLE
Bump baseimage from v3.0.1 to v3.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use ROS builder image just to get the build tools in place
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:v3.0.1 AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:v3.0.2 AS builder
 
 RUN apt update \
     && apt install -y --no-install-recommends \
@@ -19,7 +19,7 @@ RUN amd64_fix=$([ "$(uname -m)" == "x86_64" ] && echo "-Dc_args='-march=x86-64' 
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-minimal-container-image:sha-1d8d712 AS runtime
+FROM ghcr.io/tiiuae/fog-minimal-container-image:sha-aa15159 AS runtime
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD [""]


### PR DESCRIPTION
Update fog-ros-baseimage from v3.0.1 to v3.0.2