### PR TITLE
[PX4-MSGS-UPGRADE]Bump tiiuae/fog-ros-baseimage from v3.0.2 to v3.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use ROS builder image just to get the build tools in place
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:v3.0.2 AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:sha-9a1be77 AS builder
 
 RUN apt update \
     && apt install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use ROS builder image just to get the build tools in place
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:sha-9a1be77 AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:v3.1.0 AS builder
 
 RUN apt update \
     && apt install -y --no-install-recommends \


### PR DESCRIPTION
Update fog-ros-baseimage from sha-9a1be77 to v3.1.0
This PR is auto generated by a remote workflow.
Message from author of this PR;
**This version update includes the baseimage with px4-msgs 6.0.0. Components that are not using the PX4-msgs shouldnt get affected by this change.**
