### PR TITLE
Dp 8103 lmc fails to create flight logs

### DIFF
--- a/conf/default.conf
+++ b/conf/default.conf
@@ -1,7 +1,7 @@
 [General]
     TcpServerPort=5760
     ReportStats=false
-    MavlinkDialect=auto
+    MavlinkDialect=common
 
 [UdpEndpoint px4-flight-controller]
     Mode = Server

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,11 +32,11 @@ if [ "${LOGGING_DIR}" != "" ]; then
     sed -i "/.General./a \ \ \ \ Log=${LOGGING_DIR}" /etc/mavlink-router/default.conf
 
     echo " "
-    /usr/bin/mavlink-routerd -c /etc/mavlink-router/default.conf
+    exec /usr/bin/mavlink-routerd -c /etc/mavlink-router/default.conf
 
 elif [ "$1" != "" ]; then
-    /usr/bin/mavlink-routerd $args
+    exec /usr/bin/mavlink-routerd $args
 else
-    /usr/bin/mavlink-routerd
+    exec /usr/bin/mavlink-routerd
 fi
 

--- a/src/logendpoint.h
+++ b/src/logendpoint.h
@@ -104,7 +104,8 @@ protected:
     void _handle_auto_start_stop(const struct buffer *pbuf);
 
 private:
-    int _get_file(const char *extension, char *filename, size_t fnamesize);
+    int _get_file(const char *extension, char *filename, size_t fnamesize,
+                  bool use_exact_name = false);
     static uint32_t _get_prefix(DIR *dir);
     static DIR *_open_or_create_dir(const char *name);
 

--- a/src/mainloop.h
+++ b/src/mainloop.h
@@ -134,4 +134,5 @@ private:
 
     static Mainloop _instance;
     static bool _initialized;
+    bool _exit_wait_logging_idle = false;
 };

--- a/src/ulog.h
+++ b/src/ulog.h
@@ -31,10 +31,8 @@ public:
     bool start() override;
     void stop() override;
 
-    void stopping();
-
     int write_msg(const struct buffer *buffer) override;
-    int flush_pending_msgs() override { return -ENOSYS; }
+    int flush_pending_msgs() override;
 
 protected:
     ssize_t _read_msg(uint8_t *buf, size_t len) override { return 0; };
@@ -69,4 +67,6 @@ private:
     bool _logging_flush();
     void _logging_process(mavlink_logging_data_t *msg);
     bool _logging_flush_data();
+
+    void _send_stop();
 };


### PR DESCRIPTION
Needed to restructure the whole logendpoint to get one state machine instead of multiple different state variables and timeouts, which are hard to keep in sync and maintain.

Enabled graceful stop of logging in case container stop is signalled.
MavlinkDialect set to common to use PX4 ULog by default instead of trying to autodetect the dialect.
Issue with incorrect naming of the .data file fixed