### PR TITLE
Bump tiiuae/fog-ros-baseimage from v3.2.0 to v3.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use ROS builder image just to get the build tools in place
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:v3.2.0 AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:v3.3.0 AS builder
 
 RUN apt update \
     && apt install -y --no-install-recommends \


### PR DESCRIPTION
Update fog-ros-baseimage from v3.2.0 to v3.3.0
This PR is auto generated by a remote workflow.
Message from author of this PR;
**This baseimage update contains the replacement of the jfrog with digitalocean APT repository.**