### PR TITLE
Support hostnames for endpoint arguments (requirement of namespaced networking)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN amd64_fix=$([ "$(uname -m)" == "x86_64" ] && echo "-Dc_args='-march=x86-64' 
 
 FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.4.0 AS runtime
 
+# to get `getent` command (needed in entrypoint)
+RUN apt update && apt install -y libc6-utils
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD [""]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # To enable flight logging, define LOGGING_DIR env variable
 #

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,37 @@
 #                    configured amount of logfiles in the log folder.
 #                    Set to 0 to disable this functionality. Default: 0 (disabled)
 
-args=$@
+args=("$@")
+
+# Takes a list of arguments and prints transformed ones,
+# replacing HOSTNAME[...] patterns with IPs.
+resolve_hostnames() {
+    local arg
+    local new_args=()
+
+    for arg in "$@"; do
+        # Check if the argument contains a HOSTNAME[...] pattern
+        if [[ $arg =~ HOSTNAME\[([^]]*)\] ]]; then
+            local full_match="${BASH_REMATCH[0]}"  # e.g., HOSTNAME[example.com]
+            local hostname="${BASH_REMATCH[1]}"    # e.g., example.com
+
+            local ip
+            ip=$(getent hosts "$hostname" | awk '{print $1; exit}')
+
+            if [[ -z $ip ]]; then
+                echo "Error: could not resolve hostname '$hostname'" >&2
+                exit 1
+            fi
+
+            # Replace the matched pattern with the resolved IP
+            arg=${arg//"$full_match"/$ip}
+        fi
+        new_args+=("$arg")
+    done
+
+    # Print all transformed arguments
+    printf '%s\n' "${new_args[@]}"
+}
 
 if [ "${LOGGING_DIR}" != "" ]; then
     # Mavlink logging enabled
@@ -34,9 +64,11 @@ if [ "${LOGGING_DIR}" != "" ]; then
     echo " "
     exec /usr/bin/mavlink-routerd -c /etc/mavlink-router/default.conf
 
-elif [ "$1" != "" ]; then
-    exec /usr/bin/mavlink-routerd $args
 else
-    exec /usr/bin/mavlink-routerd
+    # mavlink-router does not support hostnames but raw IPs only 🫠
+    # this transforms args like `-e HOSTNAME[fog-navigation]:14590` into `-e 10.20.30.40:14590` where the IP is resolved.
+    args_with_hostnames_resolved=($(resolve_hostnames "${args[@]}"))
+
+    exec /usr/bin/mavlink-routerd "${args_with_hostnames_resolved[@]}"
 fi
 


### PR DESCRIPTION
In manifest this app is launched like this:

```json
{
                "EntrypointOpts": [
                    "-e",
                    "10.0.1.19:14590",
                    "-e",
                    "192.168.200.100:15761",
                    "0.0.0.0:14540"
                ]
}
```

The trouble with IP `10.0.1.19` is it's dependent on VM, container ID and also our IP addressing overall. Would be more robust & semantic to use hostname, but mavlink-router doesn't support hostnames: https://github.com/tiiuae/mavlink-router/blob/8ae710b5af0606fd9df2cf352ed65850fdf75dac/src/endpoint.cpp#L1328-L1340

Let's add to entrypoint the resolving so it transforms hostnames to IPs. In order to not need parsing which argument means what ("endpoint is next after -e argument") let's use a pattern like `HOSTNAME[...]` to make it obvious what's happening. While we're at it, let's replace short option with long option to make things more self-documenting:

```json
{
                "EntrypointOpts": [
                    "--endpoint=HOSTNAME[fog-navigation]:14590",
                    "--endpoint=192.168.200.100:15761",
                    "0.0.0.0:14540"
                ]
}
```

This PR adds this syntax to the endpoint. The `HOSTNAME[...]` - containing arguments are transformed before executing mavlink-router.